### PR TITLE
Update HmacCookieSessionStorage.php

### DIFF
--- a/src/Http/Session/HmacCookieSessionStorage.php
+++ b/src/Http/Session/HmacCookieSessionStorage.php
@@ -87,7 +87,7 @@ class HmacCookieSessionStorage implements SessionStorageInterface
 
         foreach ($this->bags as $bag) {
             $key = $bag->getStorageKey();
-            $sessionData[$key] = $bag->all();
+            $sessionData[$key] = $bag->getBag()->all();
         }
 
         $sessionString = base64_encode(serialize($sessionData));

--- a/tests/Http/Session/HmacCookieSessionStorageTest.php
+++ b/tests/Http/Session/HmacCookieSessionStorageTest.php
@@ -5,6 +5,7 @@ use Pho\Http\Session\HmacCookieSessionStorage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
+use Symfony\Component\HttpFoundation\Session\SessionBagProxy;
 
 class HmacCookieSessionStorageTest extends TestCase {
     public function testSaveStorage() {
@@ -19,7 +20,9 @@ class HmacCookieSessionStorageTest extends TestCase {
         $this->assertEquals('PHO_SESS', $storage->getName());
 
         // bag
-        $bag = new AttributeBag();
+        $data = [];
+        $attributeBag = new AttributeBag();
+        $bag = new SessionBagProxy($attributeBag, $data, $usageIndex);
         $storage->registerBag($bag);
         $storage->setMetadataBag();
 
@@ -29,7 +32,7 @@ class HmacCookieSessionStorageTest extends TestCase {
         $this->assertEquals(true, $storage->isStarted());
 
         // set session value
-        $bag->set('hello', 'world');
+        $bag->getBag()->set('hello', 'world');
         
         // save
         $storage->save();
@@ -48,7 +51,9 @@ class HmacCookieSessionStorageTest extends TestCase {
             'PHO_SESS' => 'YToxOntzOjE1OiJfc2YyX2F0dHJpYnV0ZXMiO2E6MTp7czo1OiJoZWxsbyI7czo1OiJ3b3JsZCI7fX0=|f75aac88e70269ce86bff907bac3468a5f393249610c95fea752992969bad8b1',
         ]);
         $response = new Response('content here');
-        $bag = new AttributeBag();
+        $data = [];
+        $attributeBag = new AttributeBag();
+        $bag = new SessionBagProxy($attributeBag, $data, $usageIndex);
         $storage->setRequest($request);
         $storage->setResponse($response);
         $storage->setName('PHO_SESS');
@@ -57,6 +62,6 @@ class HmacCookieSessionStorageTest extends TestCase {
         $storage->start();
         
         $this->assertEquals(true, $storage->isStarted());
-        $this->assertEquals('world', $bag->get('hello'));
+        $this->assertEquals('world', $bag->getBag()->get('hello'));
     }
 }


### PR DESCRIPTION
fix bug
```
Fatal error: Uncaught Error: Call to undefined method Symfony\Component\HttpFoundation\Session\SessionBagProxy::all() in /Users/light/Developer/www/framework/vendor/pho/pho/src/Http/Session/HmacCookieSessionStorage.php:90
Stack trace:
#0 /Users/light/Developer/www/framework/vendor/pho/pho/src/Http/Session/Session.php(46): Pho\Http\Session\HmacCookieSessionStorage->save()
#1 /Users/light/Developer/www/framework/vendor/pho/pho/src/Http/SessionSubscriber.php(57): Pho\Http\Session\Session->save()
#2 /Users/light/Developer/www/framework/vendor/symfony/event-dispatcher/EventDispatcher.php(260): Pho\Http\SessionSubscriber->onKernelResponse(Object(Symfony\Component\HttpKernel\Event\ResponseEvent), 'kernel.response', Object(Symfony\Component\EventDispatcher\EventDispatcher))
#3 /Users/light/Developer/www/framework/vendor/symfony/event-dispatcher/EventDispatcher.php(235): Symfony\Component\EventDispatcher\EventDispatcher->doDispatch(Array, 'kernel.response', Object(Symfony\Component\HttpKernel\Event\ResponseEvent))
#4 /Users/light/ in /Users/light/Developer/www/framework/vendor/pho/pho/src/Http/Session/HmacCookieSessionStorage.php on line 90
```